### PR TITLE
decode None as list returns TypeMismatch

### DIFF
--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -240,6 +240,11 @@ def test_cannot_decode_none_as_tuple() -> None:
     assert typedjson.decode(Tuple[str, ...], json) == DecodingError(TypeMismatch(()))
 
 
+def test_cannot_decode_none_as_list() -> None:
+    json = None
+    assert typedjson.decode(List[str], json) == DecodingError(TypeMismatch(()))
+
+
 def test_cannot_decode_fixed_tuple_with_short_sequence() -> None:
     json = (0, 1, 2)
     expectation = DecodingError(TypeMismatch(()))

--- a/typedjson/decoding.py
+++ b/typedjson/decoding.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from typing import Any
+from typing import Iterable
 from typing import Iterator
 from typing import List
 from typing import Optional
@@ -221,6 +222,9 @@ def decode_as_list(
     if origin_of(type_) is list:
         Element = args_of(type_)[0]
         list_decoded: List[Any] = []
+
+        if not isinstance(json, Iterable):
+            return DecodingError(TypeMismatch(path))
 
         for index, element in enumerate(json):
             decoded = decode(Element, element, path + (str(index),))


### PR DESCRIPTION
I fixed a problem that I reported in #11.
`typedjson.decode(List[str], None)` now returns `TypeMismatch` error.